### PR TITLE
use HACK as default font

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,21 +1,24 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# Get Vundle, the vim bundler
 mkdir -p ~/.vim/bundle/
 git clone https://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
 
+# Put our vimrc in place
 cp $DIR/vimrc ~/.vimrc
 
+# Set up fonts
 mkdir -p ~/.fonts/
 cd ~/.fonts/
-wget https://github.com/Lokaltog/powerline/raw/develop/font/PowerlineSymbols.otf
+# Hack font
+wget https://github.com/chrissimpkins/Hack/releases/download/\
+v2.010/Hack-v2_010-otf.zip -O hack.zip
+unzip -u hack.zip && rm -f hack.zip
 cd -
+
+# Update fonts
 fc-cache -vf ~/.fonts
 
-
-mkdir -p ~/.fonts.conf.d/
-cd ~/.fonts.conf.d/
-wget https://github.com/Lokaltog/powerline/raw/develop/font/10-powerline-symbols.conf
-cd -
-
+# Install all the bundles specified in .vimrc
 vim +BundleInstall +qall

--- a/vimrc
+++ b/vimrc
@@ -42,8 +42,8 @@ augroup vimrc_autocmds
     autocmd FileType python set nowrap
     augroup END
 
-" Powerline setup
-set guifont=DejaVu\ Sans\ Mono\ for\ Powerline\ 9
+" Font Hack as the default font
+set guifont=Hack\ 9
 set laststatus=2
 
 " Nerdtree setup
@@ -91,9 +91,9 @@ let g:pymode_syntax_space_errors = g:pymode_syntax_all
 let g:pymode_folding = 0
 
 " Set solarized colour scheme
+set background=dark
+silent! colorscheme solarized
 "
 " If everything is too bright and high contrast, then export
 " TERM=xterm-256color and uncomment the following line:
 "let g:solarized_termcolors=256
-set background=dark
-colorscheme solarized


### PR DESCRIPTION
If you want to, set Hack as the default font to use in graphical tools, rather than powerline.
