### PR TITLE
Script cleanup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,24 +1,73 @@
 #!/bin/bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Enable debug if argument passed to script
+if [[ "${1}" =~ debug ]]; then
+	set -x
+fi
+
+# Check for dependencies
+DEPS=""
+type git &>/dev/null || DEPS="  git\n"
+type vim &>/dev/null || DEPS+="  vim\n"
+type wget &>/dev/null || DEPS+="  wget\n"
+
+if [[ -n "${DEPS}" ]] ; then
+	echo "Please install missing dependencies:"
+	echo -e "${DEPS}"
+	exit 1
+fi
+
+# Fail the whole script if one part fails
+set -eo pipefail
+finish() {
+	if [[ $? -ne 0 ]]; then
+		set +x
+		echo -e "\nSorry, something went wrong. Try running with debug, i.e.:"
+		echo -e "  ${0} --debug\n"
+	fi
+}
+trap finish EXIT
+
+# Directory containing the script, so that we can copy other files out
+DIR="$(dirname "$(readlink -f "${0}")")"
 
 # Get Vundle, the vim bundler
-mkdir -p ~/.vim/bundle/
-git clone https://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
+mkdir -p "${HOME}/.vim/bundle/"
+if [[ -d "${HOME}/.vim/bundle/vundle/.git" ]]; then
+	( cd "${HOME}/.vim/bundle/vundle"
+	echo "Pulling vundle updates from GitHub"
+	git pull origin master &>/dev/null
+	cd - >/dev/null )
+else
+	echo "Cloning vundle from GitHub"
+	git clone https://github.com/gmarik/vundle.git "${HOME}/.vim/bundle/vundle" &>/dev/null
+fi
 
 # Put our vimrc in place
-cp $DIR/vimrc ~/.vimrc
+echo "Installing vimrc config"
+cp "${DIR}/vimrc" "${HOME}/.vimrc"
 
-# Set up fonts
-mkdir -p ~/.fonts/
-cd ~/.fonts/
-# Hack font
-wget https://github.com/chrissimpkins/Hack/releases/download/\
-v2.010/Hack-v2_010-otf.zip -O hack.zip
-unzip -u hack.zip && rm -f hack.zip
-cd -
-
-# Update fonts
-fc-cache -vf ~/.fonts
+# Grab hack font if it doesn't exist
+if [[ ! "$(fc-list |grep -i hack)" ]]; then
+	( mkdir -p "${HOME}/.fonts/"
+	cd "${HOME}/.fonts/"
+	echo "Downloading Hack font"
+	wget -q https://github.com/chrissimpkins/Hack/releases/download/\
+v2.019/Hack-v2_019-otf.zip -O hack.zip
+	unzip -qu hack.zip && rm -f hack.zip
+	cd - >/dev/null
+	# Update fonts
+	fc-cache -f "${HOME}/.fonts" )
+fi
 
 # Install all the bundles specified in .vimrc
 vim +BundleInstall +qall
+
+# Advise user of overrides
+cat << EOF
+All done!
+
+You can put custom settings in ~/.vimrc_overrides, e.g. run:
+echo setlocal spell spelllang=en_au >> ~/.vimrc_overides
+
+EOF

--- a/vimrc
+++ b/vimrc
@@ -53,8 +53,8 @@ set laststatus=2
 
 " (optional) If everything is too bright and high contrast, then uncomment
 " the next 2 lines:
-set term=screen-256color
-let g:solarized_termcolors=256
+"set term=screen-256color
+"let g:solarized_termcolors=256
 set background=dark
 " loading the solarized colorscheme is silent to prevent error during initial install
 silent! colorscheme solarized


### PR DESCRIPTION
I just wanted to skip the download of hack seeing as I already had it, but then I realised I also had it installed on Korora so figured I may as well just check if it's installed.. and then before I knew it things got out of hand and the script is now more robust (in case others want to use it).

It'd be good if you could quickly test it on OS X or me.

Also I noticed in re-setting up my machine that ce97f240306e1 enabled the 256 terminal by default but that actually breaks my machine. I think, based on the comment, that you normally just set that yourself so maybe it was accidentally committed.

I've set that back to a comment but now that we have ~/.vimrc_overrides you can just whack the correct term setting for you in there.
