### PR TITLE
Add set shell=/bin/bash to vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1,3 +1,4 @@
+set shell=/bin/bash
 set nocompatible
 filetype off
 


### PR DESCRIPTION
For people running odd shells (fish at least) Vundle will not work.

The solution seems to be setting the shell to /bin/bash in .vimrc.