### PR TITLE
updates: fixes, reformats, add configs, new plugins, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,35 +10,51 @@ To setup vim just run the setup.sh script.
 
 This script will then install all the bundles listed in the vimrc file.
 
-NOTE: If you use vim as your default editor, make sure you update your alternatives to be something other then vim.tiny (e.g. vim.nox).
+NOTE: If you use vim as your default editor, make sure you update your
+alternatives to be something other then vim.tiny (e.g. vim.nox).
 
 You may also want to set git to use vim:
 ```bash
 git config --global core.editor vim
 ```
 ## Features
-  * Toggle the nerdtree (filesystem) split with <f2>
+  * Override settings with .vimrc.local
+  * Add your own vundles with .vimrc.local.vundles
+  * Toggle the nerdtree (filesystem) split with \<CTRL+n\> or \<F2\>
     * Use '?' once in the split to get shortcuts, like 's'
+  * Nerdtree also shows git status on files
+  * Opens in Nerdtree view by default if no file specified
+  * Open a file directly to a line, e.g. vim file:20
   * Solarized colour theme with dark background
-  * Tab is 2 spaces
+  * Tab is 4 spaces by default, override this per language or in .vimrc.local
   * Hack as the default font (in graphical vim like gvim, or macvim)
-  * Powerline bar at the bottom gives you:
+  * Airline bar at the bottom gives you:
     * Git branch
     * File encoding
     * and more!
-  * Toggle a class browser (tagbar) split with <f9>
-    * tagbar not enabled by default as it requires ctags. Uncomment in vimrc to make it work.
+  * Toggle a class browser (tagbar) split with \<F9\> (requires ctags to be
+installed)
+  * Highlights column 80, so you can manage width properly
+  * YAML files are treated as Ansible
+  * Auto-generate TOC for markdown files with :GenTocGFM
+  * Syntastic checks syntax for range of file formats, python, bash, etc
+  * Better terminal integration to make it more graphical like, mous click goes
+to visual mode, hold down SHIFT for traditional buffer copy and paste with
+middle mouse
+  * Shows whitespace at end of lines and hard tabs with special chars
+  * Shortcuts for switching buffers (bn bp) and tabs (tn, tp) next and previous
+  * ctrlp adds fuzzy file searching, activatge with \<CTRL+p\> oddly enough
 
 ### Python specific features
   * Show python docs with 'K'
   * Runs through pyflakess and pep8 on save
-  * Auto fix pep8 has been mapped to <F8>
+  * Auto fix pep8 has been mapped to \<F8\>
   * Python auto complete
   * Tracks trailing white spaces
-  * Highlights column 80, so you can manage width properly
   * Uses vundle to manage vim plugins
   * Fugitive plugin for git
   * Jedi for auto complete
-  * If tagbar is setup <f9> will open a class browser.
+  * If tagbar is setup \<F9\> will open a class browser.
 
-NOTE: Hopefully gg=G and <F8> will now be enough to fix indents and at least the simple pep8 issues in your python code.
+NOTE: Hopefully gg=G and \<F8\> will now be enough to fix indents and at least
+the simple pep8 issues in your python code.

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Enable debug if argument passed to script
 if [[ "${1}" =~ debug ]]; then
@@ -20,6 +20,7 @@ fi
 # Fail the whole script if one part fails
 set -eo pipefail
 finish() {
+	# shellcheck disable=SC2181
 	if [[ $? -ne 0 ]]; then
 		set +x
 		echo -e "\nSorry, something went wrong. Try running with debug, i.e.:"
@@ -37,7 +38,8 @@ mkdir -p "${HOME}/.vim/bundle/"
 if [[ -d "${HOME}/.vim/bundle/vundle/.git" ]]; then
 	( cd "${HOME}/.vim/bundle/vundle"
 	echo "Pulling vundle updates from GitHub"
-	git pull origin master &>/dev/null
+	git remote update &>/dev/null
+	git reset --hard origin/master &>/dev/null
 	cd - >/dev/null )
 else
 	echo "Cloning vundle from GitHub"
@@ -48,13 +50,21 @@ fi
 echo "Installing vimrc config"
 cp "${DIR}/vimrc" "${HOME}/.vimrc"
 
+# Copy the example local files if not already existing
+for config in vimrc.local vimrc.local.vundles vimrc.local.vundles.disable; do
+	if [[ ! -e "${HOME}/.${config}" ]]; then
+		cp "${DIR}/${config}" "${HOME}/.${config}"
+	fi
+done
+
 # Grab hack font if it doesn't exist
-if [[ ! "$(fc-list |grep -i hack)" ]]; then
+if [[ ! "$(fc-list |grep Hack-)" ]]; then
 	( mkdir -p "${HOME}/.fonts/"
 	cd "${HOME}/.fonts/"
 	echo "Downloading Hack font"
-	wget -q https://github.com/chrissimpkins/Hack/releases/download/\
-v2.019/Hack-v2_019-otf.zip -O hack.zip
+	wget -q https://github.com/source-foundry/Hack/releases/download\
+/v3.000/Hack-v3.000-ttf.zip \
+-O hack.zip
 	unzip -qu hack.zip && rm -f hack.zip
 	cd - >/dev/null
 	# Update fonts
@@ -62,13 +72,21 @@ v2.019/Hack-v2_019-otf.zip -O hack.zip
 fi
 
 # Install all the bundles specified in .vimrc
-vim +BundleInstall +qall
+vim +PluginInstall +qall
+
+# Vim detects mutt emails (with filetype plugin on) so set wrapping
+mkdir -p ~/.vim/ftplugin
+cat > ~/.vim/ftplugin/mail.vim << EOF
+setl tw=62
+setl fo+=aw
+EOF
 
 # Advise user of overrides
 cat << EOF
 All done!
 
-You can put custom settings in ~/.vimrc_overrides, e.g. run:
-echo setlocal spell spelllang=en_au >> ~/.vimrc_overrides
+* You can put custom settings in ~/.vimrc.local
+* Add your own vim bundles to ~/.vimrc.local.vundles
+* Disable vim bundles with ~/.vimrc.local.vundles.disable
 
 EOF

--- a/vimrc
+++ b/vimrc
@@ -1,98 +1,179 @@
 " Vim needs a POSIX shell
-if $SHELL =~ 'bin/fish'
+if $SHELL !~ 'bin/bash'
     set shell=/bin/sh
 endif
 
 set nocompatible
 filetype off
 
+" set the runtime path to include Vundle and initialize
 set rtp+=~/.vim/bundle/vundle/
-call vundle#rc()
+call vundle#begin()
 
 " let Vundle manage Vundle
-" required! 
-Bundle 'gmarik/vundle'
-Bundle 'vim-airline/vim-airline'
-Bundle 'vim-airline/vim-airline-themes'
-Bundle 'tpope/vim-fugitive'
-Bundle 'scrooloose/nerdtree'
-Bundle 'klen/python-mode'
-Bundle 'davidhalter/jedi-vim'
-Bundle 'chase/vim-ansible-yaml'
-Bundle 'altercation/vim-colors-solarized'
-Bundle 'majutsushi/tagbar'
-Bundle 'airblade/vim-gitgutter'
-Bundle 'ctrlpvim/ctrlp.vim'
-Bundle 'christoomey/vim-tmux-navigator'
+" required!
+Plugin 'gmarik/vundle'
 
-" The bundles you install will be listed here
+" Navigation
+Plugin 'scrooloose/nerdtree' "File system explorer for the Vim editor
+Plugin 'ctrlpvim/ctrlp.vim' "Fuzzy file, buffer, mru, tag, etc finder
+Plugin 'bogado/file-line' "Open a file in a given line, e.g. vim file:20
 
-filetype plugin indent on
+" Language related
+Plugin 'klen/python-mode' "Helps you to create python code very quickly
+Plugin 'davidhalter/jedi-vim' "Python autocompletion with Vim
+Plugin 'majutsushi/tagbar' "Displays tags in a window, ordered by scope
+Plugin 'mzlogin/vim-markdown-toc' "Generate markdown TOC
+" If file type not detected:
+" :set ft=ansible
+" Or set something like this in ~/.vimrc.local
+" au BufRead,BufNewFile */playbooks/*.yaml set filetype=ansible
+Plugin 'pearofducks/ansible-vim' "Syntax highlighting Ansible's common filetypes
+Plugin 'vim-syntastic/syntastic' "Syntax checking hacks for vim
 
-" The rest of your config follows here
+" Beautify Vim
+Plugin 'altercation/vim-colors-solarized' "Precision colorscheme for the vim text editor
+Plugin 'vim-airline/vim-airline' "Lean & mean status/tabline for vim that's light as air
+Plugin 'vim-airline/vim-airline-themes' "Themes for airline
+Plugin 'wincent/terminus' "Better terminal integration
 
+" Git related
+Plugin 'tpope/vim-fugitive' "The best Git wrapper of all time
+Plugin 'airblade/vim-gitgutter' "shows a git diff in the gutter (sign column)
+Plugin 'Xuyuanp/nerdtree-git-plugin' "NERDTree showing git status flags
+
+" Load any custom vundles
+silent! source ~/.vimrc.local.vundles
+
+" All of your Plugins must be added before the following line
+call vundle#end()            " required
+filetype plugin indent on    " required
+
+" Solarized theme - set first so it doesn't override other settings
+" Loading the solarized colorscheme is silent to prevent error on install
+silent! colorscheme solarized
+set background=dark
+" This expects that your console is running with 16 colour Solarized palette, so
+" if everything is too bright and high contrast, then uncomment the next 2 lines
+"set term=screen-256color
+"let g:solarized_termcolors=256
+
+" Vim general settings
 syntax enable
+set nowrap
+set formatoptions-=t " Don't auto wrap!
 set incsearch
 set hlsearch
-set sw=2
-set ts=2
-set expandtab
+" Default to 4 space tabs
+set tabstop=4
+set softtabstop=4
+set shiftwidth=4
+set noexpandtab
 "set textwidth=79
-
-" Set cursor crosshairs (column, line)
-"set cuc
-set cul
+set cul " Set horizontal bar (line) in cursor crosshairs
+set colorcolumn=81 " 80 characters limit
+highlight ColorColumn ctermbg=Black ctermfg=DarkRed
+set spell spelllang=en_au
+set spell
+nnoremap zn ]s
+nnoremap zp [s
+nnoremap zz :setlocal spell! spell?<CR>
 
 " Hide buffers instead of closing them
 set hidden
 
-" Set list to show white space
-"set list
-"set listchars=tab:»·,trail:§,extends:¬,precedes:«,nbsp:§
+" Show tabs and trailing spaces (large black square U+2B1B)
+set listchars=tab:»·,trail:·
+set list
 
-" If your running OSX and backspace doesn't behave correctly uncomment this
+" If you're running OSX and backspace doesn't behave correctly uncomment this
 " following line
 "set backspace=indent,eol,start
+highlight NonText guifg=#4a4a59
+highlight SpecialKey guifg=#4a4a59
 
 " Font Hack as the default font
+" This only affects graphical vim
 set guifont=Hack\ 9
 set laststatus=2
-"
-" Set solarized colour scheme
 
-" (optional) If everything is too bright and high contrast, then uncomment
-" the next 2 lines:
-"set term=screen-256color
-"let g:solarized_termcolors=256
-set background=dark
-" loading the solarized colorscheme is silent to prevent error during initial install
-silent! colorscheme solarized
+" Shortcuts for switching buffers
+nnoremap <C-b> :buffers<CR>:buffer<Space>
+nnoremap bn :bnext<CR>
+nnoremap bp :bprevious<CR>
+nnoremap bc :bdelete<CR>
+nnoremap bC :bdelete!<CR>
+" Shortcuts for switching tabs
+nnoremap tn :tabnext<CR>
+nnoremap tp :tabprevious<CR>
 
-augroup vimrc_autocmds
-    autocmd!
-    " highlight characters past column 80
-    autocmd FileType python highlight Excess ctermbg=DarkGrey guibg=Black
-    autocmd FileType python match Excess /\%80v.*/
-    autocmd FileType python set nowrap
-    augroup END
+" Terminus setup
+let g:TerminusFocusReporting=0
+
+" ctrlp setup
+let g:ctrlp_working_path_mode = 'r'
+let g:ctrlp_user_command = ['.git', 'cd %s && git ls-files -co --exclude-standard']
+let g:ctrlp_prompt_mappings = {
+    \ 'AcceptSelection("e")': ['<c-x>'],
+    \ 'AcceptSelection("t")': ['<cr>', '<2-LeftMouse>'],
+    \ }
+" Setup some default ignores
+let g:ctrlp_custom_ignore = {
+  \ 'dir':  '\v[\/](\.(git|hg|svn)|\_site)$',
+  \ 'file': '\v\.(exe|so|dll|class|png|jpg|jpeg)$',
+\}
+
+let g:ctrlp_cmd = 'CtrlPMRU'
 
 " Tagbar setup
-" NOTE: you need ctags installed, so will keep this commented out for now
-"nmap <F9> :TagbarToggle<CR>
+" NOTE: you need ctags installed
+nmap <F9> :TagbarToggle<CR>
 " (Optional) If you are on OSX or have ctags (non-BSD) installed somewhere else not in
 " your path, use to following line to point to it.
 "let g:tagbar_ctags_bin="/usr/local/Cellar/ctags/5.8_1/bin/ctags"
 
 " Nerdtree setup
-map <F2> :NERDTreeToggle<CR>
+map <C-n> :NERDTreeToggle<CR>
+autocmd StdinReadPre * let s:std_in=1
+autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | NERDTree | endif
+autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTree") && b:NERDTree.isTabTree()) | q | endif
+
+" Ansible setup
+" Treat all .yml files as ansible, cause they probably are
+au BufRead,BufNewFile *.{yaml,yml} set filetype=ansible
+
+" Syntastic setup
+set statusline+=%#warningmsg#
+set statusline+=%{exists('g:loaded_syntastic_plugin')?SyntasticStatuslineFlag():''}
+set statusline+=%*
+let g:syntastic_always_populate_loc_list = 1
+let g:syntastic_auto_loc_list = 1
+let g:syntastic_check_on_open = 1
+let g:syntastic_check_on_wq = 0
+let g:syntastic_python_checkers = ['flake8', 'pyflakes', 'pylint']
 
 " Airline Setup
-"  smarter tab line
-"let g:airline#extensions#tabline#enabled = 1
-"
-"  Separators can be configured independently for the tabline
-"let g:airline#extensions#tabline#left_sep = ' '
-"let g:airline#extensions#tabline#left_alt_sep = '|'
+" Enable the list of buffers
+let g:airline#extensions#tabline#enabled = 1
+" Show just the filename
+let g:airline#extensions#tabline#fnamemod = ':t'
+" Separators can be configured independently for the tabline
+let g:airline#extensions#tabline#left_sep = ' '
+let g:airline#extensions#tabline#left_alt_sep = '|'
+let g:airline#extensions#tabline#enabled = 1
+
+" Language specific settings
+augroup vimrc_autocmds
+    autocmd!
+    autocmd FileType python set tabstop=4
+    autocmd FileType python set softtabstop=4
+    autocmd FileType python set shiftwidth=4
+    autocmd FileType python set expandtab
+    autocmd FileType yaml set tabstop=2
+    autocmd FileType yaml set softtabstop=2
+    autocmd FileType yaml set shiftwidth=2
+    autocmd FileType yaml set expandtab
+augroup END
 
 " Python-mode
 " Activate rope
@@ -139,5 +220,14 @@ let g:pymode_folding = 0
 
 " Finally, load any overrides from the local box
 " (silent in case it doesn't exist)
+" The old location for the file
 silent! source ~/.vimrc_overrides
+" New location
+silent! source ~/.vimrc.local
+" Disable any plugins
+silent! source ~/.vimrc.local.vundles.disable
 
+" Vim cheats
+" {visual}gq % format the visually selected area
+" gqq        % format the current line
+" gg=G       % format whole file

--- a/vimrc.local
+++ b/vimrc.local
@@ -1,0 +1,23 @@
+" Example for custom vimrc settings
+" 1) Copy to ~/.vimrc.local
+" 2) Set your custom settings
+" 3) Run ./setup.sh
+
+" Examples:
+
+" Linux style guide
+"set tabstop=8
+"set softtabstop=8
+"set shiftwidth=8
+"set noexpandtab
+
+" macro for println
+"function! InsertMarker()
+"	let string = "printf(\":::::::::: %s:%d:%s() - \\n\", FILE, LINE, func);"
+"	call append(line('.'), string)
+"endfunction
+
+" mm keys execute the marker
+"command Marker call InsertMarker()
+"map mm :Marker<enter>
+

--- a/vimrc.local.vundles
+++ b/vimrc.local.vundles
@@ -1,0 +1,16 @@
+" Example for custom vundles
+" 1) Copy to ~/.vimrc.local.vundles
+" 2) Put your own vundles
+" 3) Run ./setup.sh
+
+" Examples:
+
+" Provides rust syntax used by YCM and syntastic
+"Plugin 'rust-lang/rust.vim'
+
+" Note, YCM will compile various tools and libs itself
+" for language support, e.g. rust
+" See:
+" https://github.com/Valloric/YouCompleteMe#fedora-linux-x64
+"Plugin 'valloric/YouCompleteMe'
+

--- a/vimrc.local.vundles.disable
+++ b/vimrc.local.vundles.disable
@@ -1,0 +1,11 @@
+" To disable a plugin, vundle expects you to just comment it out or remote the
+" line.
+"
+" This does not help when you want to keep the vimrc identical to upstream.
+"
+" To work around this, you can remove the plugin from the runtimepath.
+
+" Examples:
+
+" The example below disables vim-airline:
+"set runtimepath-=~/.vim/bundle/vim-airline


### PR DESCRIPTION
@matthewoliver I forgot to send this upstream to you, if you wanna test it and merge it let me know and I'll pull your upstream into my master, else I'll just go my own way :-)

setup.sh:
 - Ignore shellcheck warning

 - Make vundle update more robust with git reset --hard

 - Copy in local files to homedir if they don't exist, make it easier to use them

 - Make hack font check more exact to avoid mismatches with other fonts

 - Update Hack font to v3.000

 - Update vundle to use PluginInstall instead of deprecated BundleInstall

 - Add filetype plugin for mutt to set wrapping

vimrc:
 - Vundle updates:

   * Re-format vimrc to use Vundle's recommended config:
     https://github.com/VundleVim/Vundle.vim#quick-start

   * Users can include own custom vundles file with .vimrc.local.vundles

   * Users can disable vundles listed in vimrc by removing vundle from path, with
     .vimrc.local.vundles.disable, e.g.  disable vim-airline:
       set runtimepath-=~/.vim/bundle/vim-airline

 - Vundle plugins:

   * Add pearofducks/ansible-vim: syntax highlighting Ansible's common filetypes
     * Set all yaml files to be ansible filetype to use plugin

   * Remove chase/vim-ansible-yaml (deprecated)

   * Add mzlogin/vim-markdown-toc: generate table of contents for Markdown files
     * Generate with: :GenTocGFM

   * Add Xuyuanp/nerdtree-git-plugin: plugin of NERDTree showing git status flags

   * Add vim-syntastic/syntastic: Syntax checking hacks for vim
     * Set python checkers to flake8, pyflakes, pylint

   * Add bogado/file-line: open a file in a given line
     * To use, run vim like so to open at line 20: vim file:20

   * Add wincent/terminus: Better terminal integration
     * Mouse click goes into vim visual mode
     * Use SHIFT for regular copy and middle-click paste
     * Insert mode goes to pipe, while normal mode is char highlight

 - Enable spelling by default

 - Set spelling to English Australian by default, non-Aussies can override this
   using own .vimrc.local file

 - Add shortcuts for enabling spelling (zz) and next (zn) and previous (zp)
   misspelled words

 - Modify shell check to support all other random shells, rather than just fish

 - Fix solarized theme load ordering. colorscheme has to be set before changing
   the term and background, settings else they get the defaults

 - Set nowrap by default, previously this was python only

 - Show column 80 by default and highlight chars that go over, previously this
   was python only, and make it solorized compatible

 - Set default tabs to expanded 4 spaces and make others language specific using
   autocmds, e.g. python set to expanded 4 spaces, yaml set to expanded 2 spaces

 - Only show spaces and trailing spaces by default in whitespace, else code gets
   too messy. Override with vimrc.local if you prefer something more heavy like
   the original:

     set listchars=tab:»·,trail:§,extends:¬,precedes:«,nbsp:§

 - Add shortcuts for switching buffers:

    nnoremap bn :bnext<CR>
    nnoremap bp :bprevious<CR>
    nnoremap bc :bdelete<CR>
    nnoremap bC :bdelete!<CR>

 - Add shortcuts for switching tabs:

    nnoremap tn :tabnext<CR>
    nnoremap tp :tabprevious<CR>

 - Add configuration for ctrlp, search buffers and files by default, skip
   git repos and binary files like images.

 - Enable ctags shortcut by default, no problems if ctags isn't not installed

 - Set some more NERD defaults, open NERD if no file specified, close vim
   if only NERD window left, set shortcut to C-n as F2 is often a media key.

 - Enable and configure airline by default.

 - Support .vimrc.local (easier to type than .vimrc_overrides)

 - Provide and copy example files:
    * vimrc.local
    * vimrc.local.bundles
    * vimrc.local.bundles.disable